### PR TITLE
Temporary workaround for p4est library loading error

### DIFF
--- a/p4est.rb
+++ b/p4est.rb
@@ -45,6 +45,9 @@ class P4est < Formula
     system "make"
     system "make", "check" if build.with? "check"
     system "make", "install"
+    # Temporary workaround for library loading error (library not in path)
+    include.install_symlink Dir["#{prefix}/FAST/include/*h"]
+    lib.install_symlink Dir["#{prefix}/FAST/lib/*.*"]
 
     # slow / debug
     args_debug = ["--prefix=#{prefix}/DEBUG",


### PR DESCRIPTION
On Ubuntu, there is a executable link-time error that suggests that the
library not in path. This patch forces a symlink of the FAST library to
<HB>/include and <HB>/lib to work around this issue.
