### PR TITLE
Update deal.II to version 8.4.1

### DIFF
--- a/dealii.rb
+++ b/dealii.rb
@@ -4,8 +4,8 @@ require_relative "requirements/cmake_requirement"
 class Dealii < Formula
   desc "open source finite element library"
   homepage "http://www.dealii.org"
-  url "https://github.com/dealii/dealii/releases/download/v8.4.0/dealii-8.4.0.tar.gz"
-  sha256 "36a20e097a03f17b557e11aad1400af8c6252d25f7feca40b611d5fc16d71990"
+  url "https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.tar.gz"
+  sha256 "00a0e92d069cdafd216816f1aff460f7dbd48744b0d9e0da193287ebf7d6b3ad"
 
   bottle do
     cellar :any

--- a/parmetis.rb
+++ b/parmetis.rb
@@ -26,12 +26,12 @@ class Parmetis < Formula
   # bug fixes from PETSc developers
   patch do
     url "https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/"
-    sha256 "704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d"
+    sha256 "0349f5bc19a2ba9fe9e1b9d385072dabe59262522bd7cf66f26c6bc31bbb1b86"
   end
 
   patch do
     url "https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/"
-    sha256 "4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b"
+    sha256 "baec5e1fa6bb4f6c59e3ede564485e0ad743f58c9875fd65cb715b5c14a491b5"
   end
 
   def install

--- a/superlu_dist.rb
+++ b/superlu_dist.rb
@@ -23,7 +23,7 @@ class SuperluDist < Formula
   # fix duplicate symbols [mc64dd_,mc64ed_,mc64fd_] when linking with superlu
   patch do
     url "https://bitbucket.org/petsc/pkg-superlu_dist/commits/2faf8669a2ba20250ffe2d8a1b63d4f8ef8c5b74/raw/"
-    sha256 "67e2966e1a9b4e3471374d1e720946c2ef34403d00e796767b51718e4d50604f"
+    sha256 "6594950e4ab9dabfcd8a2a76e0da8a7388655a96a2cd2654c1eb5084effb7185"
   end
 
   def install


### PR DESCRIPTION
Update deal.II to version 8.4.1. Fixes [compilation issues](https://github.com/dealii/dealii/releases/tag/v8.4.1) with older GCC.
